### PR TITLE
test link clicking, fix navigating on prevented links

### DIFF
--- a/lib/route-on-event.js
+++ b/lib/route-on-event.js
@@ -11,7 +11,7 @@ exports.routeFromLinkClick = function routeFromLinkClick (event, router) {
   // ignore if it could open a new window, if a right click
   if (
     event.metaKey || event.shiftKey || event.ctrlKey || event.altKey ||
-    event.which === 3 || event.button === 2
+    event.which === 3 || event.button === 2 || event.defaultPrevented
   ) return
 
   // ignore if not a link click

--- a/lib/router.js
+++ b/lib/router.js
@@ -53,7 +53,7 @@ Router.prototype = Object.create(EventEmitter.prototype, {
     if (this.isListening) this.stop() // remove listeners from previous options
     var evtname = this.hash ? 'hashchange' : 'popstate'
     win.addEventListener(evtname, this, false)
-    if (opts && opts.routeLinks) {
+    if (opts && opts.routeLinks && !this.hash) {
       win.document.addEventListener('click', this, false)
     }
     this.isListening = true

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "karma-tap": "^1.0.3",
     "karma-tap-reporter": "0.0.4",
     "phantomjs": "^1.9.18",
-    "standard": "^5.3.1"
+    "standard": "^5.3.1",
+    "synthetic-dom-events": "^0.3.0"
   },
   "scripts": {
     "lint": "standard lib",

--- a/test/client.js
+++ b/test/client.js
@@ -3,8 +3,9 @@ import Router from '../lib/router'
 
 // run same tests as on server
 import './server'
+import './links'
 
-function once(event) {
+function once (event) {
   let resolve
   window.addEventListener(event, function handle () {
     window.removeEventListener(event, handle, false)

--- a/test/links.js
+++ b/test/links.js
@@ -1,0 +1,77 @@
+import test from 'blue-tape'
+import Router from '../lib/router'
+import event from 'synthetic-dom-events'
+
+function once (event) {
+  let resolve
+  function handle () {
+    window.removeEventListener(event, handle, false)
+    window.document.removeEventListener(event, handle, false)
+    resolve()
+  }
+  window.addEventListener(event, handle, false)
+  window.document.addEventListener(event, handle, false)
+  return new Promise(r => resolve = r)
+}
+
+function click (node) {
+  node.dispatchEvent(event('click', { bubbles: true, cancelable: true }))
+}
+
+test('Router#start ignores prevented link clicks', async t => {
+  let routing
+  let called = 0
+  let router = new Router()
+    .on('route', (args, promise) => { routing = promise })
+    .use('/start', ({ resolve }) => resolve())
+    .use('/linked/:to', ({ params, resolve }) => {
+      ++called
+      t.fail('should not route due to default prevented')
+      resolve()
+    })
+    
+  history.replaceState(null, document.title, '/start')
+  router.start({ routeLinks: true })
+  await routing
+
+  let clicking = once('click')
+  let link = document.body.appendChild(document.createElement('a'))
+  link.href = '/linked/location'
+  link.addEventListener('click', evt => evt.preventDefault())
+  click(link)
+  await clicking
+  await routing
+
+  document.body.removeChild(link)
+  router.stop()
+  t.equal(called, 0, 'matching route should not be called')
+})
+
+test('Router#start listens to link clicks if routeLinks is true', async t => {
+  let routing
+  let called = 0
+  let router = new Router()
+    .on('route', (args, promise) => { routing = promise })
+    .use('/start', ({ resolve }) => resolve())
+    .use('/linked/:to', ({ params, resolve }) => {
+      ++called
+      t.equal(params.to, 'location', 'param to should be set')
+      resolve()
+    })
+
+  history.replaceState(null, document.title, '/start')
+  router.start({ routeLinks: true })
+  await routing
+
+  let clicking = once('click')
+  let link = document.createElement('a')
+  link.href = '/linked/location'
+  document.body.appendChild(link)
+  click(link)
+  await clicking
+  await routing
+
+  document.body.removeChild(link)
+  router.stop()
+  t.equal(called, 1, 'matching route should be called')
+})


### PR DESCRIPTION
When hash routing, there is no need to intercept clicks, since hash changes don't cause navigation anyway.

When the event has `defaultPrevented` already don't navigate. That way the existing behavior of the browser is maintained.

fixes #7 