### PR TITLE
add routing promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,15 @@ router = new Router()
 
 Defaults to `false`, meaning routing will be based on `location.pathname`.
 If `true`, enables routing based on `location.hash`.
-If a string value begining with `'#'`, the string prefix will be ignored when routing.
+If a string value beginning with `'#'`, the string prefix will be ignored when routing.
+
+### Router#routing: ?Promise
+
+```js
+await router.routing
+```
+
+The same promise returned by `route()`, representing the current routing flow. This is `null` when there is no currently running flow.
 
 ### Router#start(options: ?Object): Router
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -24,6 +24,7 @@ function Router (options) {
 
   this.middleware = []
   this.isListening = false
+  this.routing = null
 
   options = options || {}
   var hash = options.hash === true ? '#' : options.hash
@@ -161,6 +162,7 @@ Router.prototype = Object.create(EventEmitter.prototype, {
    * @returns {Promise} Promise that resolves when the whole middleware series completes.
    */
   route: method(function route (url, state) {
+    var self = this
     var exit
     var isHashRouting = Boolean(this.hash)
     var location = parseUrl(url, {
@@ -188,6 +190,11 @@ Router.prototype = Object.create(EventEmitter.prototype, {
     // start asynchronously
     var promise = Promise.resolve(args)
       .then(middleRun(this.middleware))
+
+    self.routing = promise
+    function unsetRouting () { self.routing = null }
+    promise.then(unsetRouting, unsetRouting)
+
     this.emit('route', args, promise)
     if (exit) this.once('route', exit)
 
@@ -200,6 +207,7 @@ Router.prototype = Object.create(EventEmitter.prototype, {
    * @returns {Function} An express middleware-compatible function.
    */
   expressHandler: method(function expressHandler () {
+    var self = this
     return function (req, res, next) {
       var args = {
         location: parseUrl(req.url, true),
@@ -211,10 +219,15 @@ Router.prototype = Object.create(EventEmitter.prototype, {
         next: function () { next() } // discard arguments
       }
       var promise = Promise.resolve(args)
-        .then(middleRun(this.middleware))
-        .catch(next)
-      this.emit('route', args, promise)
-    }.bind(this)
+        .then(middleRun(self.middleware))
+
+      self.routing = promise
+      function unsetRouting () { self.routing = null }
+      promise.then(unsetRouting, unsetRouting)
+
+      promise.catch(next)
+      self.emit('route', args, promise)
+    }
   })
 })
 

--- a/test/server.js
+++ b/test/server.js
@@ -12,12 +12,14 @@ test('Router#constructor can be called as a function', async t => {
   let router = Router()
   t.ok(router instanceof Router, 'Router() should return an instanceof Router')
   t.equal(router.hash, false, 'hash should be false by default')
+  t.equal(router.routing, null, 'routing should be null by default')
 })
 
 test('Router#constructor can be called as a constructor', async t => {
   let router = new Router()
   t.ok(router instanceof Router, 'new Router() should return an instanceof Router')
   t.equal(router.hash, false, 'hash should be false by default')
+  t.equal(router.routing, null, 'routing should be null by default')
 })
 
 test('Router#use returns the router', async t => {
@@ -41,6 +43,9 @@ test('Router#route returns a promise', async t => {
   let router = new Router().use('/', ({ resolve }) => { resolve() })
   let value = router.route('/')
   t.ok(value.then && value.catch, 'route should return a promise')
+  t.equal(router.routing, value, 'routing should be the same promise returned by route()')
+  await value
+  t.equal(router.routing, null, 'routing should be null after finished')
 })
 
 test('Router#route logs an error if no route matches', async t => {


### PR DESCRIPTION
`routing` should refer to the same promise returned by `route()`, until it resolves, and then it should be `null`.