### PR TITLE
add beforeExit confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ let router = Router()
     path // /page/123
     params.id // 123
   })
+  // beforeExit registration
+  .get('/form', ({ beforeExit }) => {
+    beforeExit(event => {
+      if (isFormDirty) return 'Are you sure you want to leave?'
+    })
+  })
   // Routers can be nested
   .get('/section', Router()
     .get('/page', async ({ path, resolve, exiting }) => {
@@ -114,6 +120,12 @@ Start listening for hashchange/popstate events, and optionally link click events
 #### options.routeLinks
 
 Defaults to `false`, meaning link clicks are not handled. If `true`, link clicks will trigger a call to `navigate` with the link's `href`.
+
+#### options.confirm
+
+Defaults to `window.confirm`. A function that takes a confirm message string returns a boolean. The function is called to confirm if a `beforeExit` handler prevents default, or returns a confirmation message. A `true` returned from this function means that navigation will continue. A `false` means the user stays.
+
+It is recommended that you use a custom function that calls `window.confirm` with a static localized message, and your `beforeExit` handlers just call `event.preventDefault()`.
 
 ### Router#stop(): Router
 
@@ -271,6 +283,12 @@ Path parameters specified with a `:` in the `use(path)` are added to the `params
 #### state
 
 `state` is an object intended to mirror the state object given to `history.pushState` and recieved from `history.onpopstate`.
+
+#### beforeExit
+
+Call `beforeExit` with a callback function. The function will handle `beforeunload` events on the window, and `beforeexit` events on the router. To prompt users to confirm before leaving, either call `event.preventDefault()`, set `event.returnValue` to a string, or return a string. See [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload) on cross-browser handling of `beforeunload`.
+
+Note that handlers registered with `beforeExit` are automatically removed when the user completes navigation. This can be either because no handler prevented the navigation, or the user confirmed the navigation.
 
 #### exiting
 

--- a/lib/route-on-event.js
+++ b/lib/route-on-event.js
@@ -4,7 +4,8 @@
 var win = typeof window === 'undefined' ? null : window
 
 exports.routeFromLocation = function routeFromLocation (event, router) {
-  router.route(win.location.href)
+  var state = (event && event.type === 'popstate') ? event.state : win.history.state
+  router.route(win.location.href, state)
 }
 
 exports.routeFromLinkClick = function routeFromLinkClick (event, router) {
@@ -34,4 +35,74 @@ exports.routeFromLinkClick = function routeFromLinkClick (event, router) {
     path = path.slice(path.indexOf(hash) + hash.length)
   }
   router.navigate(path)
+}
+
+exports.registerBeforeExit = function (router, callback, context) {
+  // ensure no duplicate handler
+  win.removeEventListener('beforeunload', router, false)
+  win.addEventListener('beforeunload', router, false)
+  router.on('beforeexit', function (event) {
+    var returnValue = callback.call(context, event)
+    if (typeof returnValue === 'string') {
+      event.returnValue = returnValue
+    }
+  })
+}
+
+exports.beforeUnload = function (event, router) {
+  // true if there were listeners
+  if (router.emit('beforeexit', event)) {
+    return event.returnValue
+  }
+}
+
+exports.shouldNavigate = function (router) {
+  if (!win || !router.isListening) return true
+  var event = {
+    target: win.document,
+    type: 'beforeexit',
+    returnValue: null,
+    preventDefault: function () {
+      event.defaultPrevented = true
+    }
+  }
+  router.emit('beforeexit', event)
+  var defaultPrevented = event.defaultPrevented || (
+    event.returnValue && typeof event.returnValue === 'string'
+  )
+  var confirmed = !defaultPrevented || router.confirm(event.returnValue || '')
+  if (confirmed) {
+    win.removeEventListener('beforeunload', router, false)
+    router.removeAllListeners('beforeexit')
+  }
+  return confirmed
+}
+
+exports.shouldRoute = function (router, location) {
+  if (!win || !router.isListening) return true
+
+  var entries = router.entries ||
+    (router.entries = { list: [], index: -1, length: -1 })
+  var index = entries.index + 1
+  var isNewEntry = entries.length !== win.history.length
+  if (!isNewEntry) {
+    index = entries.list.lastIndexOf(location.href)
+    if (index === -1) {
+      index = entries.index + 1
+      isNewEntry = true
+    }
+  }
+  var delta = entries.index - index
+  entries.list[(entries.index = index)] = location.href
+  entries.length = win.history.length
+  if (isNewEntry) entries.list.length = index + 1
+
+  alert(location.href + ' ' + JSON.stringify(entries))
+  if (exports.shouldNavigate(router)) return true
+  alert(delta)
+  if (delta) {
+    entries.index += delta
+    win.history.go(delta)
+  }
+  return false
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -16,6 +16,7 @@ function method (fn) {
     value: fn
   }
 }
+var noop = function () {}
 
 /**
  * Creates a new Router. The new keyword is optional.
@@ -28,6 +29,7 @@ function Router (options) {
   if (!(this instanceof Router)) return new Router(options)
 
   EventEmitter.call(this)
+  options = options || {}
 
   // bind handleEvent since jsdom doesn't use the right `this`
   // https://github.com/tmpvar/jsdom/issues/1382
@@ -36,8 +38,9 @@ function Router (options) {
   this.middleware = []
   this.isListening = false
   this.routing = null
+  this.confirm = null
+  this.entries = null
 
-  options = options || {}
   var hash = options.hash === true ? '#' : options.hash
   this.hash = hash && hash.charAt(0) === '#' ? hash : false
 }
@@ -58,6 +61,7 @@ Router.prototype = Object.create(EventEmitter.prototype, {
    *
    * @param {Object} [options] Options for how the router will run.
    * @param {boolean} [options.routeLinks=false] true/false to enable/disable listening to link clicks, and handling with navigate.
+   * @param {Function} [options.confirm=window.confirm] Function that asks for confirmation before navigating. Returns true/false.
    * @emits Router#route
    * @returns {Router} this
    */
@@ -65,9 +69,10 @@ Router.prototype = Object.create(EventEmitter.prototype, {
     if (this.isListening) this.stop() // remove listeners from previous options
     var evtname = this.hash ? 'hashchange' : 'popstate'
     win.addEventListener(evtname, this, false)
-    if (opts && opts.routeLinks && !this.hash) {
-      win.document.addEventListener('click', this, false)
+    if (opts && opts.routeLinks) {
+      win.addEventListener('click', this, false)
     }
+    this.confirm = (opts && opts.confirm) || (win && win.confirm)
     this.isListening = true
     handler.routeFromLocation(null, this)
     return this
@@ -81,15 +86,19 @@ Router.prototype = Object.create(EventEmitter.prototype, {
   stop: method(function stop () {
     var evtname = this.hash ? 'hashchange' : 'popstate'
     win.removeEventListener(evtname, this, false)
-    win.document.removeEventListener('click', this, false)
+    win.removeEventListener('beforeunload', this, false)
+    win.removeEventListener('click', this, false)
     this.isListening = false
     return this
   }),
 
   /** @private */
   handleEvent: method(function handleEvent (event) {
-    if (event.type === 'click') return handler.routeFromLinkClick(event, this)
-    return handler.routeFromLocation(event, this)
+    switch (event.type) {
+      case 'click': return handler.routeFromLinkClick(event, this)
+      case 'beforeunload': return handler.beforeUnload(event, this)
+      default: return handler.routeFromLocation(event, this)
+    }
   }),
 
   /**
@@ -101,6 +110,8 @@ Router.prototype = Object.create(EventEmitter.prototype, {
    * @returns {Router} this
    */
   navigate: method(function navigate (path, state, title) {
+    if (!handler.shouldNavigate(this)) return this
+
     if (this.hash) {
       win.location.hash = this.hash + path // will trigger hashchange
     } else {
@@ -119,10 +130,11 @@ Router.prototype = Object.create(EventEmitter.prototype, {
    * @returns {Router} this
    */
   replace: method(function replace (path, state, title) {
+    if (!handler.shouldNavigate(this)) return this
+
     if (this.hash) {
       win.location.replace(
-        win.location.href.replace(/#.*$/, '')
-        + this.hash + path
+        win.location.href.replace(/#.*$/, '') + this.hash + path
       )
     } else {
       win.history.replaceState(state, title || win.document.title, path)
@@ -181,6 +193,11 @@ Router.prototype = Object.create(EventEmitter.prototype, {
       isHashRouting: isHashRouting,
       hashPrefix: this.hash
     })
+
+    if (!handler.shouldRoute(this, location, state)) {
+      return Promise.resolve()
+    }
+
     var args = {
       location: location,
       path: location.pathname,
@@ -188,6 +205,9 @@ Router.prototype = Object.create(EventEmitter.prototype, {
       state: state,
       router: this,
       context: {},
+      beforeExit: (!win || !this.isListening) ? noop : function (fn, ctx) {
+        handler.registerBeforeExit(self, fn, ctx)
+      },
       next: function () {
         console.error('no route matches ' + args.path)
       }
@@ -229,6 +249,7 @@ Router.prototype = Object.create(EventEmitter.prototype, {
         response: res,
         router: self,
         context: {},
+        beforeExit: noop,
         next: function () { next() } // discard arguments
       }
       var promise = Promise.resolve(args)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "synthetic-dom-events": "^0.3.0"
   },
   "scripts": {
-    "lint": "standard lib",
+    "lint": "standard 'lib/**/*.js'",
     "test": "npm run lint && npm run test-server && npm run test-client",
     "test-server": "mocha -r babel-register test/server.js",
     "test-client": "karma start"

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -54,4 +54,13 @@ describe('Route middleware arguments', () => {
       }))
     await topRouter.route('/')
   })
+
+  it('has a beforeExit function', async () => {
+    let router = Router()
+      .use(({ beforeExit, resolve }) => {
+        assert.equal(typeof beforeExit, 'function', 'beforeExit must be a function')
+        resolve()
+      })
+    await router.route('/')
+  })
 })

--- a/test/links.js
+++ b/test/links.js
@@ -19,12 +19,23 @@ function click (node) {
   node.dispatchEvent(event('click', { bubbles: true, cancelable: true }))
 }
 
+async function clickLinkTo (url, preventDefault) {
+  let clicking = once('click')
+  let link = document.createElement('a')
+  link.href = url
+  if (preventDefault) {
+    link.addEventListener('click', evt => evt.preventDefault())
+  }
+  document.body.appendChild(link)
+  click(link)
+  await clicking
+  document.body.removeChild(link)
+}
+
 describe('Router#start', () => {
   it('ignores prevented link clicks', async () => {
-    let routing
     let called = 0
     let router = new Router()
-      .on('route', (args, promise) => { routing = promise })
       .use('/start', ({ resolve }) => resolve())
       .use('/linked/:to', ({ params, resolve }) => {
         ++called
@@ -34,26 +45,18 @@ describe('Router#start', () => {
 
     history.replaceState(null, document.title, '/start')
     router.start({ routeLinks: true })
-    await routing
+    await router.routing
 
-    let clicking = once('click')
-    let link = document.body.appendChild(document.createElement('a'))
-    link.href = '/linked/location'
-    link.addEventListener('click', evt => evt.preventDefault())
-    click(link)
-    await clicking
-    await routing
+    await clickLinkTo('/linked/location', true)
+    await router.routing
 
-    document.body.removeChild(link)
     router.stop()
     assert.equal(called, 0, 'matching route should not be called')
   })
 
   it('listens to link clicks if routeLinks is true', async () => {
-    let routing
     let called = 0
     let router = new Router()
-      .on('route', (args, promise) => { routing = promise })
       .use('/start', ({ resolve }) => resolve())
       .use('/linked/:to', ({ params, resolve }) => {
         ++called
@@ -63,18 +66,284 @@ describe('Router#start', () => {
 
     history.replaceState(null, document.title, '/start')
     router.start({ routeLinks: true })
-    await routing
+    await router.routing
 
-    let clicking = once('click')
-    let link = document.createElement('a')
-    link.href = '/linked/location'
-    document.body.appendChild(link)
-    click(link)
-    await clicking
-    await routing
+    await clickLinkTo('/linked/location')
+    await router.routing
 
-    document.body.removeChild(link)
     router.stop()
     assert.equal(called, 1, 'matching route should be called')
+  })
+
+  it('triggers beforeExit handlers on link clicks', async () => {
+    let called = 0
+    let beforeExitCalled = 0
+    let router = new Router()
+      .use('/start', ({ resolve, beforeExit }) => {
+        beforeExit(evt => {
+          ++beforeExitCalled
+          assert.equal(typeof evt, 'object', 'beforeExit should pass an event object')
+          assert.equal(evt.type, 'beforeexit', 'beforeExit event object is of type "beforeexit"')
+        })
+        resolve()
+      })
+      .use('/linked/:to', ({ params, resolve }) => {
+        ++called
+        resolve()
+      })
+
+    history.replaceState(null, document.title, '/start')
+    router.start({ routeLinks: true })
+    await router.routing
+
+    await clickLinkTo('/linked/location')
+    await router.routing
+
+    router.stop()
+    assert.equal(called, 1, 'matching route should be called')
+    assert.equal(beforeExitCalled, 1, 'beforeExit handler should be called')
+  })
+
+  it('confirms exit if beforeExit handlers prevents default', async () => {
+    let called = 0
+    let confirmCalled = 0
+    let beforeExitCalled = 0
+    let confirm = message => {
+      ++confirmCalled
+      assert.equal(message, '', 'the confirm message should be empty')
+      return false
+    }
+    let router = new Router()
+      .use('/start', ({ resolve, beforeExit }) => {
+        beforeExit(evt => {
+          ++beforeExitCalled
+          evt.preventDefault()
+        })
+        resolve()
+      })
+      .use('/linked/:to', ({ params, resolve }) => {
+        ++called
+        resolve()
+      })
+
+    history.replaceState(null, document.title, '/start')
+    router.start({ confirm, routeLinks: true })
+    await router.routing
+
+    await clickLinkTo('/linked/location')
+    await router.routing
+
+    router.stop()
+    assert.equal(called, 0, 'matching route should not be called')
+    assert.equal(confirmCalled, 1, 'confirm should be called')
+    assert.equal(beforeExitCalled, 1, 'beforeExit handler should be called')
+  })
+
+  it('confirms exit and reverts url if beforeExit handlers prevents default', async () => {
+    let called = 0
+    let startCalled = 0
+    let confirmCalled = 0
+    let beforeExitCalled = 0
+    let confirm = message => {
+      ++confirmCalled
+      assert.equal(message, '', 'the confirm message should be empty')
+      return false
+    }
+    let router = new Router({ hash: '#' })
+      .use('/start', ({ resolve, beforeExit }) => {
+        ++startCalled
+        beforeExit(evt => {
+          ++beforeExitCalled
+          evt.preventDefault()
+        })
+        resolve()
+      })
+      .use('/linked/:to', ({ params, resolve }) => {
+        ++called
+        resolve()
+      })
+
+    let eventing = once('hashchange')
+    location.hash = '#/start'
+    await eventing
+    router.start({ confirm })
+    await router.routing
+
+    eventing = once('hashchange')
+    await clickLinkTo('#/linked/location')
+    await eventing
+    await router.routing
+
+    router.stop()
+    assert.equal(location.hash, '#/start', 'change should have been reverted')
+    assert.equal(startCalled, 1, 'starting route should be called only once')
+    assert.equal(called, 0, 'matching route should not be called')
+    assert.equal(confirmCalled, 1, 'confirm should be called')
+    assert.equal(beforeExitCalled, 1, 'beforeExit handler should be called')
+  })
+
+  it('reverts to the correct location when navigation canceled', async () => {
+    let lastTo
+    let router = new Router({ hash: '#' })
+      .use('/go/:to', ({ params, beforeExit, resolve }) => {
+        lastTo = params.to
+        beforeExit(evt => evt.preventDefault())
+        resolve()
+      })
+
+    let eventing = once('hashchange')
+    location.hash = '#/go/0'
+    await eventing
+    router.start({ confirm: () => true })
+    await router.routing
+
+    async function go (to, confirm) {
+      alert(`go ${to} ${confirm}`)
+      router.confirm = () => confirm
+      let eventing = once('hashchange')
+      await clickLinkTo(to)
+      await eventing
+      if (!confirm) await null
+      await router.routing
+    }
+
+    async function historyGo (delta, confirm) {
+      alert(`history go ${delta}`)
+      router.confirm = () => confirm
+      let eventing = once('hashchange')
+      history.go(delta)
+      await eventing
+      if (!confirm) await null
+      await router.routing
+    }
+
+    await go('#/go/1', true)
+    await go('#/go/2', true)
+
+    await go('#/go/3', false)
+    assert.equal(location.hash, '#/go/2', 'should revert to 2')
+    assert.equal(lastTo, '2', 'should have last run 2')
+
+    await historyGo(-1, true)
+    assert.equal(location.hash, '#/go/1', 'should go back to 1')
+    assert.equal(lastTo, '1', 'should have last run 1')
+
+    await historyGo(1, true)
+    assert.equal(location.hash, '#/go/2', 'should go forward to 2')
+    assert.equal(lastTo, '2', 'should have last run 2')
+
+    await go('#/go/1', true)
+    await historyGo(-1, true)
+
+    await historyGo(-1, false)
+    assert.equal(location.hash, '#/go/2', 'should revert to 2')
+    assert.equal(lastTo, '2', 'should have last run 2')
+  })
+
+  it('confirms exit if beforeExit handlers sets a returnValue', async () => {
+    let called = 0
+    let confirmCalled = 0
+    let beforeExitCalled = 0
+    let confirm = message => {
+      ++confirmCalled
+      assert.equal(message, 'U Shure?', 'the confirm message should be set')
+      return true
+    }
+    let router = new Router()
+      .use('/start', ({ resolve, beforeExit }) => {
+        beforeExit(evt => {
+          ++beforeExitCalled
+          evt.returnValue = 'U Shure?'
+        })
+        resolve()
+      })
+      .use('/linked/:to', ({ params, resolve }) => {
+        ++called
+        resolve()
+      })
+
+    history.replaceState(null, document.title, '/start')
+    router.start({ confirm, routeLinks: true })
+    await router.routing
+
+    await clickLinkTo('/linked/location')
+    await router.routing
+
+    router.stop()
+    assert.equal(called, 1, 'matching route should be called since confirmed')
+    assert.equal(confirmCalled, 1, 'confirm should be called')
+    assert.equal(beforeExitCalled, 1, 'beforeExit handler should be called')
+  })
+
+  it('confirms exit if beforeExit handlers returns a confirm message', async () => {
+    let called = 0
+    let confirmCalled = 0
+    let beforeExitCalled = 0
+    let confirm = message => {
+      ++confirmCalled
+      assert.equal(message, 'U Shure?', 'the confirm message should be set')
+      return true
+    }
+    let router = new Router()
+      .use('/start', ({ resolve, beforeExit }) => {
+        beforeExit(evt => {
+          ++beforeExitCalled
+          return 'U Shure?'
+        })
+        resolve()
+      })
+      .use('/linked/:to', ({ params, resolve }) => {
+        ++called
+        resolve()
+      })
+
+    history.replaceState(null, document.title, '/start')
+    router.start({ confirm, routeLinks: true })
+    await router.routing
+
+    await clickLinkTo('/linked/location')
+    await router.routing
+
+    router.stop()
+    assert.equal(called, 1, 'matching route should be called since confirmed')
+    assert.equal(confirmCalled, 1, 'confirm should be called')
+    assert.equal(beforeExitCalled, 1, 'beforeExit handler should be called')
+  })
+
+  it('removes beforeExit handlers after confirming exit', async () => {
+    let called = 0
+    let confirmCalled = 0
+    let beforeExitCalled = 0
+    let confirm = message => {
+      ++confirmCalled
+      return true
+    }
+    let router = new Router()
+      .use('/start', ({ resolve, beforeExit }) => {
+        beforeExit(evt => {
+          ++beforeExitCalled
+          evt.preventDefault()
+        })
+        resolve()
+      })
+      .use('/linked/:to', ({ params, resolve }) => {
+        ++called
+        resolve()
+      })
+
+    history.replaceState(null, document.title, '/start')
+    router.start({ confirm, routeLinks: true })
+    await router.routing
+
+    await clickLinkTo('/linked/location')
+    await router.routing
+
+    await clickLinkTo('/linked/elsewhere')
+    await router.routing
+
+    router.stop()
+    assert.equal(called, 2, 'matching route should be called since confirmed')
+    assert.equal(confirmCalled, 1, 'confirm should be called only once')
+    assert.equal(beforeExitCalled, 1, 'beforeExit handler should be called only once')
   })
 })


### PR DESCRIPTION
Add `beforeExit` function to the middleware arguments.

On server or client that is not listening to events, the function does nothing.

On client, when listening to events, but not routing links, it throws an error, since it cannot prevent routing if it isn't intercepting link clicks.

On client, when listening to events and routing links, it takes a function as its first parameter, and registers it as a `beforeunload` handler on `window` and as a `beforeexit` handler on the router. When a link is clicked, or `navigate` is called, the handlers are run.

Each handler receives an `event` object as the first parameter. If the handler calls `event.preventDefault()`, sets `event.returnValue` to a string, or returns a string, the user is prompted to confirm the navigation. If no handlers cause a prompt, or the user confirms navigation, all registered handlers are removed.

The `start(options)` function takes an additional `confirm` option property, which must be a function that returns a boolean if the user confirms navigation. By default `window.confirm` is used. The message given in `event.returnValue` is passed to the function.

I recommend that users should pass in a custom function that uses a static localized message passed to `window.confirm`, and return the result. That way this confirmation more closely matches the behavior of the browser when handling `beforeunload`. (Most browsers no longer actually display the text in `event.returnValue`)

This fixes #4