### PR TITLE
add the lazy method

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -9,6 +9,9 @@ var parseUrl = typeof window === 'undefined'
   ? require('url').parse
   : require('./url').parse
 
+var slice = Array.prototype.slice
+var map = Array.prototype.map
+
 function Router (options) {
   if (!(this instanceof Router)) return new Router(options)
 
@@ -40,6 +43,16 @@ function method (fn) {
     writable: true,
     value: fn
   }
+}
+
+function lazyLoad (step) {
+  var self = this
+  if (self.loaded) return self.fn(step)
+  return Promise.resolve(self.fn(step)).then(function (fn) {
+    if (fn instanceof Router) fn = middleRun(fn.middleware)
+    self.loaded = true
+    return (self.fn = fn)(step)
+  })
 }
 
 Router.prototype = Object.create(EventEmitter.prototype, {
@@ -77,7 +90,7 @@ Router.prototype = Object.create(EventEmitter.prototype, {
   }),
 
   use: method(function use (path) {
-    var callbacks = [].slice.call(arguments, 1)
+    var callbacks = slice.call(arguments, 1)
     if (path && typeof path !== 'string') {
       callbacks.unshift(path)
       path = null
@@ -91,6 +104,13 @@ Router.prototype = Object.create(EventEmitter.prototype, {
     })
 
     return this
+  }),
+
+  lazy: method(function lazy () {
+    return this.use.apply(this, map.call(arguments, function (fn) {
+      if (typeof fn !== 'function') return fn
+      return lazyLoad.bind({ fn: fn, loaded: false })
+    }))
   }),
 
   route: method(function route (path, state) {


### PR DESCRIPTION
```
Router()
  .lazy('/esnext', () => 
    System.import('./esnext/router').then(({default}) => default)
  )
  .lazy('/commonjs', () => new Promise((resolve) => require.ensure(
    [], (require) => resolve(require('./commonjs/router')), 'commonjs'
  )))
  .lazy('/amd', () =>
    new Promise((resolve) => require('./amd/router', resolve))
  )
```