### PR TITLE
Run client tests in jsdom

### DIFF
--- a/jsdom.conf.js
+++ b/jsdom.conf.js
@@ -1,0 +1,4 @@
+// The default url for jsdom is 'about:blank', which causes all url helpers to explode
+require('jsdom-global')(null, {
+  url: 'http://example.com/'
+})

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "babel-runtime": "^6.6.1",
     "babelify": "^7.2.0",
     "browserify": "^14.0.0",
+    "jsdom": "9.12.0",
+    "jsdom-global": "2.1.1",
     "karma": "^1.3.0",
     "karma-browserify": "^5.1.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -38,9 +40,10 @@
   },
   "scripts": {
     "lint": "standard lib/**/*.js",
-    "test": "npm run lint && npm run test-server && npm run test-client",
+    "test": "npm run lint && npm run test-server && npm run test-client && npm run test-jsdom",
     "test-server": "mocha -r babel-register test/server.js",
-    "test-client": "karma start"
+    "test-client": "karma start",
+    "test-jsdom": "mocha -r babel-register -r jsdom.conf.js -r babel-polyfill test/client.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://github.com/thetalecrafter/middle-router/pull/59.

Turns out `url.js` works fine in jsdom, just not with the default `about:blank` url. I'm opening this PR in case you want to support jsdom going forward, feel free to reject.